### PR TITLE
Updated spellcheck to contemporary version

### DIFF
--- a/.github/workflows/spellcheck-action.yml
+++ b/.github/workflows/spellcheck-action.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     # The checkout step
     - uses: actions/checkout@master
-    - uses: rojopolis/spellcheck-github-actions@0.27.0
+    - uses: rojopolis/spellcheck-github-actions@0.44.0
       name: Spellcheck
       with:
         config_path: config/.spellcheck.yml


### PR DESCRIPTION
Hello

As the maintainer of the [spellcheck GitHub action](https://github.com/marketplace/actions/github-spellcheck-action) I am sunsetting the used version as by the proposed [sunset policy](https://github.com/rojopolis/spellcheck-github-actions/wiki#sunset-policy)

I just updated the action to the latest version, alternatively you can alter the code to point to `v0` which is a canonical version. I do not use this approach myself if I can avoid it, but it is widely used for GitHub Actions.

Let me know if you have any issues with the proposed PR and I will do my best to accommodate.

I can recommend [Dependabot](https://github.com/dependabot) for keeping your GitHub actions up to date, alternatively there are [Renovate](https://github.com/marketplace/renovate), if you want a PR proposing a basic configuration for Dependabot, please let me know.

jonasbn
